### PR TITLE
Remove leading space from keywords.txt identifier token

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,17 +6,17 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-BounceMatrix	 KEYWORD1
+BounceMatrix	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-update	 KEYWORD2
-interval	 KEYWORD2
-read	 KEYWORD2
-write	 KEYWORD2
-rebounce	 KEYWORD2
+update	KEYWORD2
+interval	KEYWORD2
+read	KEYWORD2
+write	KEYWORD2
+rebounce	KEYWORD2
 risingEdge	KEYWORD2
 fallingEdge	KEYWORD2
 


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. Leading spaces on a keyword identifier causes it to not be recognized by the Arduino IDE. On Arduino IDE 1.6.5 and newer an unrecognized keyword identifier causes the default editor.function.style highlighting to be used (as with KEYWORD2, KEYWORD3, LITERAL2).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords